### PR TITLE
Keep intersphinx objects.inv after build

### DIFF
--- a/nbsite/tests/test_cmd.py
+++ b/nbsite/tests/test_cmd.py
@@ -429,7 +429,7 @@ def test_build_deletes_by_default(tmp_project_with_docs_skeleton):
     build('html', str(project / "builtdocs"), project_root=str(project), examples_assets='')
     assert not (project / "builtdocs" / ".doctrees").is_dir()
     assert (project / "builtdocs" / "First_Notebook.html").is_file()
-    assert len(list((project / "builtdocs").iterdir())) == 9
+    assert len(list((project / "builtdocs").iterdir())) == 10
 
 @pytest.mark.slow
 def test_build_with_clean_dry_run_does_not_delete(tmp_project_with_docs_skeleton):

--- a/scripts/nbsite_cleandisthtml.py
+++ b/scripts/nbsite_cleandisthtml.py
@@ -40,7 +40,7 @@ for folder in (".doctrees", "_sources"):
     except:
         pass
 
-for file_ in ("objects.inv",):
+for file_ in ():
     f = os.path.join(htmldir,file_)
     try:
         if dry_run:


### PR DESCRIPTION
Closes #153 

It looks like ever since the HTML generation was "cleaned" to reduce upload size it has been deleting the `objects.inv` file. This is needed by any other sphinx project that would like to link to pyviz documentation more easily using the intersphinx extension.

This PR removes objects.inv from the delete list. I wasn't sure if you would like the entire loop to be removed so I made it an empty tuple for now.