### PR TITLE
Check for main URL for gallery links, for other deployment types

### DIFF
--- a/nbsite/gallery/gen.py
+++ b/nbsite/gallery/gen.py
@@ -273,9 +273,13 @@ def generate_file_rst(app, src_dir, dest_dir, page, section, backend,
                     deployed_file = os.path.join(deployment_url, basename)
                 else:
                     deployed_file = os.path.join(deployment_url, name)
+                # First try name at deployment_url, then try deployment_url itself
                 r = requests.get(deployed_file)
                 if r.status_code != 200:
-                    deployed_file = False
+                    deployed_file = deployment_url
+                    r = requests.get(deployed_file)
+                    if r.status_code != 200:
+                        deployed_file = False
 
             if nblink in ['top', 'both']:
                 add_nblink(rst_file, host, deployed_file, download_as,


### PR DESCRIPTION
Right now, links are generated for the pages on examples.pyviz.com to deployed apps with URLs like https://euler.pyviz.demo.anaconda.com/euler, but https://github.com/pyviz-topics/examples/pull/83 adds an example that doesn't follow that convention; the app is only deployed at https://voila-gpx-viewer.pyviz.demo.anaconda.com/ and not https://voila-gpx-viewer.pyviz.demo.anaconda.com/voila-gpx-viewer.  The euler example would work at either, but in some cases the two link styles go to different pages, e.g. https://attractors.pyviz.demo.anaconda.com/ is the Bokeh overview page, not the full dashboard that's at https://attractors.pyviz.demo.anaconda.com/attractors_panel . 

This PR attempts to make the gallery first try https://X.pyviz.demo.anaconda.com/X for an example X, and then if it's not found, try 
https://X.pyviz.demo.anaconda.com/.  I haven't tested that it will actually work; not sure how to do so without making a dev release.

