### PR TITLE
Skipping possible SyntaxErrors while thumbnailing

### DIFF
--- a/nbsite/gallery/thumbnailer.py
+++ b/nbsite/gallery/thumbnailer.py
@@ -87,7 +87,9 @@ class ThumbnailProcessor(Preprocessor):
 
     def preprocess_cell(self, cell, resources, index):
         if cell['cell_type'] == 'code':
-            template = 'from nbsite.gallery.thumbnailer import thumbnail;thumbnail({{expr}}, {basename!r})'
+            template = """from nbsite.gallery.thumbnailer import thumbnail
+try: eval('thumbnail({{expr}}, {basename!r})')
+except SyntaxError: pass"""
             cell['source'] = wrap_cell_expression(cell['source'],
                                                   template.format(
                                                       basename=self.basename))


### PR DESCRIPTION
A cell ending in a semicolon would cause a SyntaxError using the current approach. This PR aims to skip these cases (which is fine as a semicolon suppresses display output anyway) safely using eval.

Note: not yet tested!