### PR TITLE
Skipping thumbnailing for expressions with trailing semicolons

### DIFF
--- a/examples/sites/holoviews/holoviews/ipython/preprocessors.py
+++ b/examples/sites/holoviews/holoviews/ipython/preprocessors.py
@@ -48,6 +48,8 @@ def wrap_cell_expression(source, template='{expr}'):
                               + ([expr_end_slice] if expr_end_slice else []))
             ending = '\n'.join(([expr_start_slice] if expr_start_slice else [])
                             + filtered[last_expr.lineno:])
+            if ending.strip().endswith(';'): # IPython semicolon display semantics
+                pass
             # BUG!! Adds newline for 'foo'; <expr>
             return start + '\n' + template.format(expr=ending)
     return source

--- a/nbsite/gallery/thumbnailer.py
+++ b/nbsite/gallery/thumbnailer.py
@@ -140,7 +140,7 @@ if __name__ == '__main__':
         print('Generating thumbnail for file {filename}'.format(filename=f))
         code = notebook_thumbnail(f, subpath)
         try:
-            retcode = execute(code.encode('utf8'), cwd=os.path.split(f)[0])
+            retcode = execute(code.encode('utf8'), cwd=os.path.split(f)[0], env={})
         except Exception as e:
             print('Failed to generate thumbnail for {filename}'.format(filename=f))
             print(str(e))

--- a/nbsite/gallery/thumbnailer.py
+++ b/nbsite/gallery/thumbnailer.py
@@ -87,9 +87,7 @@ class ThumbnailProcessor(Preprocessor):
 
     def preprocess_cell(self, cell, resources, index):
         if cell['cell_type'] == 'code':
-            template = """from nbsite.gallery.thumbnailer import thumbnail
-try: eval('thumbnail({{expr}}, {basename!r})')
-except SyntaxError: pass"""
+            template = 'from nbsite.gallery.thumbnailer import thumbnail;thumbnail({{expr}}, {basename!r})'
             cell['source'] = wrap_cell_expression(cell['source'],
                                                   template.format(
                                                       basename=self.basename))


### PR DESCRIPTION
This PR reverts the eval approach for a simpler, more focused fix.