### PR TITLE
Added support for :no_interactivity_warning: directive option

### DIFF
--- a/nbsite/__main__.py
+++ b/nbsite/__main__.py
@@ -42,7 +42,7 @@ def main(args=None):
     build_parser = subparsers.add_parser("build", help=inspect.getdoc(build))
     build_parser.add_argument('--what',type=str,help='type of output to generate',default='html')
 
-    build_parser.add_argument('--project-name', type=str, help='name of project')
+    build_parser.add_argument('--project-name', type=str, help='name of project', default='')
     build_parser.add_argument('--org',type=str,help='github organization',default='')
     build_parser.add_argument('--host',type=str,help='host to use when generating notebook links',default='GitHub')
     build_parser.add_argument('--repo',type=str,help='name of repo',default='')

--- a/nbsite/__main__.py
+++ b/nbsite/__main__.py
@@ -41,6 +41,14 @@ def main(args=None):
 
     build_parser = subparsers.add_parser("build", help=inspect.getdoc(build))
     build_parser.add_argument('--what',type=str,help='type of output to generate',default='html')
+
+    build_parser.add_argument('--project-name', type=str, help='name of project')
+    build_parser.add_argument('--org',type=str,help='github organization',default='')
+    build_parser.add_argument('--host',type=str,help='host to use when generating notebook links',default='GitHub')
+    build_parser.add_argument('--repo',type=str,help='name of repo',default='')
+    build_parser.add_argument('--branch',type=str,help='branch to point to in notebook links',default='master')
+    build_parser.add_argument('--binder',type=str,help='where to place binder link',choices=['bottom', 'top', 'both', 'none'], default='none')
+
     build_parser.add_argument('--output',type=str,help='where to place output',default="builtdocs")
     _add_common_args(build_parser,'--project-root','--doc','--examples', '--overwrite')
     build_parser.add_argument('--examples-assets',type=str,default="assets",

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -67,19 +67,6 @@ def build(what='html',
 
     Usually this is run after `nbsite scaffold`
     """
-    env={'PROJECT_NAME':project_name,
-         'PROJECT_ROOT':project_root if project_root!='' else os.getcwd(),
-         'HOST':host,
-         'REPO':repo,
-         'BRANCH':branch,
-         'ORG':org,
-         'EXAMPLES':examples,
-         'DOC':doc,
-         'EXAMPLES_ASSETS':examples_assets,
-         'BINDER':binder
-         }
-    merged_env = dict(os.environ, **env)
-
     paths = _prepare_paths(project_root, examples=examples, doc=doc, examples_assets=examples_assets)
     if overwrite:
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -51,6 +51,12 @@ def build(what='html',
           output='builtdocs',
           project_root='',
           doc='doc',
+          project_name='',
+          host='GitHub',
+          repo='',
+          branch='master',
+          org='',
+          binder='none',
           examples='examples',
           examples_assets='assets',
           clean_dry_run=False,
@@ -61,12 +67,25 @@ def build(what='html',
 
     Usually this is run after `nbsite scaffold`
     """
+    env={'PROJECT_NAME':project_name,
+         'PROJECT_ROOT':project_root if project_root!='' else os.getcwd(),
+         'HOST':host,
+         'REPO':repo,
+         'BRANCH':branch,
+         'ORG':org,
+         'EXAMPLES':examples,
+         'DOC':doc,
+         'EXAMPLES_ASSETS':examples_assets,
+         'BINDER':binder
+         }
+    merged_env = dict(os.environ, **env)
+
     paths = _prepare_paths(project_root, examples=examples, doc=doc, examples_assets=examples_assets)
     if overwrite:
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    subprocess.check_call(["sphinx-build","-b",what,paths['doc'],output])
+    subprocess.check_call(["sphinx-build","-b",what,paths['doc'],output], env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')
     copy_files(paths['doc'], output, 'json_*')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -79,6 +79,9 @@ def build(what='html',
          'BINDER':binder
          }
     merged_env = dict(os.environ, **env)
+    none_vals = {k:v for k,v in merged_env.items() if v is None}
+    if none_vals:
+        raise Exception("Missing value for %s" % list(none_vals.keys()))
 
     paths = _prepare_paths(project_root, examples=examples, doc=doc, examples_assets=examples_assets)
     if overwrite:

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -85,7 +85,7 @@ def build(what='html',
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    subprocess.check_call(["sphinx-build","-b",what,paths['doc'],output], env=merged_env)
+    subprocess.check_call(["sphinx-build","-b",what,paths['doc'],output])
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')
     copy_files(paths['doc'], output, 'json_*')

--- a/nbsite/cmd.py
+++ b/nbsite/cmd.py
@@ -67,12 +67,25 @@ def build(what='html',
 
     Usually this is run after `nbsite scaffold`
     """
+    env={'PROJECT_NAME':project_name,
+         'PROJECT_ROOT':project_root if project_root!='' else os.getcwd(),
+         'HOST':host,
+         'REPO':repo,
+         'BRANCH':branch,
+         'ORG':org,
+         'EXAMPLES':examples,
+         'DOC':doc,
+         'EXAMPLES_ASSETS':examples_assets,
+         'BINDER':binder
+         }
+    merged_env = dict(os.environ, **env)
+
     paths = _prepare_paths(project_root, examples=examples, doc=doc, examples_assets=examples_assets)
     if overwrite:
         for path in glob.glob(os.path.join(paths['doc'], '**', '*.ipynb'), recursive=True):
             print('Removing evaluated notebook from {}'.format(path))
             os.remove(path)
-    subprocess.check_call(["sphinx-build","-b",what,paths['doc'],output])
+    subprocess.check_call(["sphinx-build","-b",what,paths['doc'],output], env=merged_env)
     print('Copying json blobs (used for holomaps) from {} to {}'.format(paths['doc'], output))
     copy_files(paths['doc'], output, '**/*.json')
     copy_files(paths['doc'], output, 'json_*')

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -35,7 +35,23 @@ import nbformat
 from nbconvert import NotebookExporter, PythonExporter, HTMLExporter
 from nbconvert.preprocessors import (ExecutePreprocessor, CellExecutionError,
                                      Preprocessor)
+from .cmd import hosts, _prepare_paths
 
+
+interactivity_warning_binder="""
+This web page was generated from a Jupyter notebook and not all
+interactivity will work on this website. <a
+href="{download_link}">Right-click to download and run</a> or <a
+href="{binder_link}">Launch on Binder</a> for full Python-backed
+interactivity.
+"""
+
+interactivity_warning="""
+This web page was generated from a Jupyter notebook and not all
+interactivity will work on this website. <a
+href="{download_link}">Right-click to download and run</a> for full
+Python-backed interactivity.
+"""
 
 #from nbformat.v4 import output_from_msg
 class ExecutePreprocessor1000(ExecutePreprocessor):
@@ -158,6 +174,17 @@ class FixBackticksInDetails(Preprocessor):
     def __call__(self, nb, resources): return self.preprocess(nb,resources)
 
 
+def get_download_link(relpath, org, branch, repo, examples, host):
+    info = (hosts[host], org, repo, branch, examples, relpath)
+    return '%s/%s/%s/%s/%s/%s' % info
+
+
+def get_binder_link(relpath, org, repo, branch, examples):
+    # SVG logo: https://mybinder.org/badge_logo.svg
+    url="https://mybinder.org/v2/gh/{org}/{repo}/{branch}?filepath={examples}/{relpath}"
+    return  url.format(org=org,repo=repo,branch=branch,relpath=relpath,examples=examples)
+
+
 class NotebookDirective(Directive):
     """Insert an evaluated notebook into a document
 
@@ -216,7 +243,6 @@ class NotebookDirective(Directive):
 
         # Evaluate Notebook and insert into Sphinx doc
         skip_exceptions = 'skip_exceptions' in self.options
-        disable_interactivity_warning = 'disable_interactivity_warning' in self.options
 
         # Parse slice
         evaluated_text = evaluate_notebook(nb_abs_path, dest_path,
@@ -226,13 +252,44 @@ class NotebookDirective(Directive):
                                            skip_execute=self.options.get('skip_execute'),
                                            skip_output=self.options.get('skip_output'),
                                            offset=self.options.get('offset', 0),
-                                           disable_interactivity_warning=disable_interactivity_warning,
                                            timeout=setup.config.nbbuild_cell_timeout,
                                            ipython_startup=setup.config.nbbuild_ipython_startup,
                                            patterns_to_take_with_me=setup.config.nbbuild_patterns_to_take_along)
 
-        # Insert evaluated notebook HTML into Sphinx
+        project_name = os.environ.get('PROJECT_NAME','')
+        project_root = os.environ.get('PROJECT_ROOT','')
+        host = os.environ.get('HOST','GitHub')
+        branch = os.environ.get('BRANCH','master')
+        repo = os.environ.get('REPO','')
+        org = os.environ.get('ORG','')
+        doc = os.environ.get('DOC','doc')
+        examples = os.environ.get('EXAMPLES','examples')
+        examples_assets = os.environ.get('EXAMPLES_ASSETS','assets')
+        binder = os.environ.get('BINDER','none')
 
+        if repo == '' or project_name == '':
+            project_name = repo = project_name or repo
+        if org == '':
+            org = repo
+
+        paths = _prepare_paths(project_root, examples=examples,
+                               doc=doc, examples_assets=examples_assets)
+        relpath = os.path.relpath(nb_abs_path, paths['examples'])
+        dl_link = get_download_link(relpath, org, branch, repo, examples, host)
+        binder_link = get_binder_link(relpath, org, repo, branch, examples)
+
+        if not ('disable_interactivity_warning' in self.options):
+            if binder == 'none':
+                inner_msg = interactivity_warning.format(download_link=dl_link)
+                evaluated_text += '''
+                <div id="scroller-right">{inner_msg}</div>'''.format(inner_msg=inner_msg)
+            else:
+                inner_msg = interactivity_warning_binder.format(download_link=dl_link,
+                                                                binder_link=binder_link)
+                evaluated_text += '''
+                <div id="scroller-right">{inner_msg}</div>'''.format(inner_msg=inner_msg)
+
+        # Insert evaluated notebook HTML into Sphinx
         self.state_machine.insert_input([link_rst], rst_file)
 
         # create notebook node
@@ -277,7 +334,7 @@ def nb_to_html(nb_path, preprocessors=[]):
 
 # TODO: (does it matter) have lost NotebookRunner.MIME_MAP['application/vnd.bokehjs_load.v0+json'] = 'html'
 # TODO: (does it matter) have lost NotebookRunner.MIME_MAP['application/vnd.bokehjs_exec.v0+json'] = 'html'
-def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=None, end=None, skip_execute=None,skip_output=None, offset=0, disable_interactivity_warning=False, timeout=300, ipython_startup=None,patterns_to_take_with_me=None):
+def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=None, end=None, skip_execute=None,skip_output=None, offset=0, timeout=300, ipython_startup=None,patterns_to_take_with_me=None):
 
     if patterns_to_take_with_me is None:
         patterns_to_take_with_me = []
@@ -328,11 +385,7 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=N
         preprocessors.append(NotebookSlice(substring, end, offset))
     if skip_output:
         preprocessors.append(SkipOutput(skip_output))
-    ret = nb_to_html(dest_path, preprocessors=preprocessors)
-
-    if not disable_interactivity_warning:
-        ret += '<div id="scroller-right">Not all interactivity in this notebook may work.</div>'
-    return ret
+    return nb_to_html(dest_path, preprocessors=preprocessors)
 
 
 def formatted_link(path):

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -168,7 +168,8 @@ class NotebookDirective(Directive):
     optional_arguments = 6
     option_spec = {'skip_exceptions' : directives.flag,
                    'substring':str, 'end':str,
-                   'skip_execute':bool, 'skip_output':str, 'offset':int}
+                   'skip_execute':bool, 'skip_output':str, 'offset':int,
+                   'no_interactivity_warning':bool}
 
     def run(self):
         # check if raw html is supported
@@ -215,6 +216,7 @@ class NotebookDirective(Directive):
 
         # Evaluate Notebook and insert into Sphinx doc
         skip_exceptions = 'skip_exceptions' in self.options
+        no_interactivity_warning = 'no_interactivity_warning' in self.options
 
         # Parse slice
         evaluated_text = evaluate_notebook(nb_abs_path, dest_path,
@@ -224,6 +226,7 @@ class NotebookDirective(Directive):
                                            skip_execute=self.options.get('skip_execute'),
                                            skip_output=self.options.get('skip_output'),
                                            offset=self.options.get('offset', 0),
+                                           no_interactivity_warning=no_interactivity_warning,
                                            timeout=setup.config.nbbuild_cell_timeout,
                                            ipython_startup=setup.config.nbbuild_ipython_startup,
                                            patterns_to_take_with_me=setup.config.nbbuild_patterns_to_take_along)
@@ -274,7 +277,7 @@ def nb_to_html(nb_path, preprocessors=[]):
 
 # TODO: (does it matter) have lost NotebookRunner.MIME_MAP['application/vnd.bokehjs_load.v0+json'] = 'html'
 # TODO: (does it matter) have lost NotebookRunner.MIME_MAP['application/vnd.bokehjs_exec.v0+json'] = 'html'
-def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=None, end=None, skip_execute=None,skip_output=None, offset=0, timeout=300, ipython_startup=None,patterns_to_take_with_me=None):
+def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=None, end=None, skip_execute=None,skip_output=None, offset=0, no_interactivity_warning=False, timeout=300, ipython_startup=None,patterns_to_take_with_me=None):
 
     if patterns_to_take_with_me is None:
         patterns_to_take_with_me = []
@@ -326,6 +329,9 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=N
     if skip_output:
         preprocessors.append(SkipOutput(skip_output))
     ret = nb_to_html(dest_path, preprocessors=preprocessors)
+
+    if not no_interactivity_warning:
+        ret += '<div id="scroller-right">Not all interactivity in this notebook may work.</div>'
     return ret
 
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -49,7 +49,7 @@ interactivity.
 interactivity_warning="""
 This web page was generated from a Jupyter notebook and not all
 interactivity will work on this website. <a
-href="{download_link}">Right-click to download and run</a> for full
+href="{download_link}">Right click to download and run locally</a> for full
 Python-backed interactivity.
 """
 

--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -169,7 +169,7 @@ class NotebookDirective(Directive):
     option_spec = {'skip_exceptions' : directives.flag,
                    'substring':str, 'end':str,
                    'skip_execute':bool, 'skip_output':str, 'offset':int,
-                   'no_interactivity_warning':bool}
+                   'disable_interactivity_warning':bool}
 
     def run(self):
         # check if raw html is supported
@@ -216,7 +216,7 @@ class NotebookDirective(Directive):
 
         # Evaluate Notebook and insert into Sphinx doc
         skip_exceptions = 'skip_exceptions' in self.options
-        no_interactivity_warning = 'no_interactivity_warning' in self.options
+        disable_interactivity_warning = 'disable_interactivity_warning' in self.options
 
         # Parse slice
         evaluated_text = evaluate_notebook(nb_abs_path, dest_path,
@@ -226,7 +226,7 @@ class NotebookDirective(Directive):
                                            skip_execute=self.options.get('skip_execute'),
                                            skip_output=self.options.get('skip_output'),
                                            offset=self.options.get('offset', 0),
-                                           no_interactivity_warning=no_interactivity_warning,
+                                           disable_interactivity_warning=disable_interactivity_warning,
                                            timeout=setup.config.nbbuild_cell_timeout,
                                            ipython_startup=setup.config.nbbuild_ipython_startup,
                                            patterns_to_take_with_me=setup.config.nbbuild_patterns_to_take_along)
@@ -277,7 +277,7 @@ def nb_to_html(nb_path, preprocessors=[]):
 
 # TODO: (does it matter) have lost NotebookRunner.MIME_MAP['application/vnd.bokehjs_load.v0+json'] = 'html'
 # TODO: (does it matter) have lost NotebookRunner.MIME_MAP['application/vnd.bokehjs_exec.v0+json'] = 'html'
-def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=None, end=None, skip_execute=None,skip_output=None, offset=0, no_interactivity_warning=False, timeout=300, ipython_startup=None,patterns_to_take_with_me=None):
+def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=None, end=None, skip_execute=None,skip_output=None, offset=0, disable_interactivity_warning=False, timeout=300, ipython_startup=None,patterns_to_take_with_me=None):
 
     if patterns_to_take_with_me is None:
         patterns_to_take_with_me = []
@@ -330,7 +330,7 @@ def evaluate_notebook(nb_path, dest_path=None, skip_exceptions=False,substring=N
         preprocessors.append(SkipOutput(skip_output))
     ret = nb_to_html(dest_path, preprocessors=preprocessors)
 
-    if not no_interactivity_warning:
+    if not disable_interactivity_warning:
         ret += '<div id="scroller-right">Not all interactivity in this notebook may work.</div>'
     return ret
 


### PR DESCRIPTION

Extends the directive with the ` :no_interactivity_warning:` as follows:

```
.. notebook:: example ../examples/Development.ipynb
    :offset: 0
    :no_interactivity_warning:
```

The CSS is specified in https://github.com/pyviz-dev/sphinx_holoviz_theme/pull/16 and obviously needs to be improved but here is the idea (when :no_interactivity_warning: is *not* specified):

![image](https://user-images.githubusercontent.com/890576/98807870-e9f92d80-23e0-11eb-910f-f970f7c992f7.png)

We should now decide what the message should be *exactly* and what link(s) it should have.
 
