### PR TITLE
Add utility to extract the release version from a package version string

### DIFF
--- a/nbsite/gallery/gen.py
+++ b/nbsite/gallery/gen.py
@@ -420,7 +420,7 @@ def generate_gallery(app, page):
             deployment_urls = []
 
         if not heading:
-            gallery_rst += f'\n\n.. raw:: html\n\n    <div class="section sphx-glr-section" id="section"></div><br>\n\n'
+            gallery_rst += '\n\n.. raw:: html\n\n    <div class="section sphx-glr-section" id="section"></div><br>\n\n'
         elif inline:
             gallery_rst += f'\n\n.. toctree::\n   :glob:\n   :hidden:\n   :maxdepth: 2\n\n   {section}/*'
         else:

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -3,7 +3,7 @@
 import os
 
 from nbsite import nbbuild
-from nbsite.util import get_release_version
+from nbsite.util import get_release_version  # noqa
 
 def setup(app):
     try:

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -3,7 +3,7 @@
 import os
 
 from nbsite import nbbuild
-from nbsite.util import get_release_version  # noqa
+from nbsite.util import base_version  # noqa
 
 def setup(app):
     try:

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -3,6 +3,7 @@
 import os
 
 from nbsite import nbbuild
+from nbsite.util import get_release_version
 
 def setup(app):
     try:

--- a/nbsite/tests/test_util.py
+++ b/nbsite/tests/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nbsite.util import get_release_version
+from nbsite.util import base_version
 
 @pytest.mark.parametrize(
     "version,expected",
@@ -16,5 +16,5 @@ from nbsite.util import get_release_version
         ("v0.3.0", "v0.3.0"),
     ]
 )
-def test_get_release_version(version, expected):
-    assert get_release_version(version) == expected
+def test_base_version(version, expected):
+    assert base_version(version) == expected

--- a/nbsite/tests/test_util.py
+++ b/nbsite/tests/test_util.py
@@ -1,0 +1,20 @@
+import pytest
+
+from nbsite.util import get_release_version
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("0.3.0", "0.3.0"),
+        ("0.13.0a19", "0.13.0a19"),
+        ("0.13.0rc1", "0.13.0rc1"),
+        ("0.13.0b1", "0.13.0b1"),
+        ("no.match", "no.match"),
+        ("0.13.0a19.post4+g0695e214", "0.13.0a19"),
+        # Only 3 compontents version are matched.
+        ("0.13.post4+g0695e214", "0.13.post4+g0695e214"),
+        ("v0.3.0", "v0.3.0"),
+    ]
+)
+def test_get_release_version(version, expected):
+    assert get_release_version(version) == expected

--- a/nbsite/util.py
+++ b/nbsite/util.py
@@ -19,7 +19,7 @@ def copy_files(src, dest, pattern='**'):
             shutil.copy(path, f)
 
 
-def get_release_version(version):
+def base_version(version):
     """Extract the final release and if available pre-release (alpha, beta,
     release candidate) segments of a PEP440 version, defined with three
     components (major.minor.micro).
@@ -28,7 +28,7 @@ def get_release_version(version):
     with a not so informative and rather ugly long version (e.g.
     ``0.13.0a19.post4+g0695e214``). Use it in ``conf.py``::
 
-        version = release = get_release_version(package.__version__)
+        version = release = base_version(package.__version__)
 
     Return the version passed as input if no match is found with the pattern.
     """

--- a/nbsite/util.py
+++ b/nbsite/util.py
@@ -1,5 +1,6 @@
 import os
 import glob
+import re
 import shutil
 
 def copy_files(src, dest, pattern='**'):
@@ -16,3 +17,25 @@ def copy_files(src, dest, pattern='**'):
         if not os.path.exists(f):
             print("cp %s %s"%(path, f))
             shutil.copy(path, f)
+
+
+def get_release_version(version):
+    """Extract the final release and if available pre-release (alpha, beta,
+    release candidate) segments of a PEP440 version, defined with three
+    components (major.minor.micro).
+    
+    Useful to avoid nbsite/sphinx to display the documentation HTML title
+    with a not so informative and rather ugly long version (e.g.
+    ``0.13.0a19.post4+g0695e214``). Use it in ``conf.py``::
+
+        version = release = get_release_version(package.__version__)
+
+    Return the version passed as input if no match is found with the pattern.
+    """
+    # look at the start for e.g. 0.13.0, 0.13.0rc1, 0.13.0a19, 0.13.0b10
+    pattern = r"([\d]+\.[\d]+\.[\d]*(?:a|rc|b)?[\d]+)"
+    match = re.match(pattern, version)
+    if match:
+        return match.group()
+    else:
+        return version

--- a/nbsite/util.py
+++ b/nbsite/util.py
@@ -33,7 +33,7 @@ def get_release_version(version):
     Return the version passed as input if no match is found with the pattern.
     """
     # look at the start for e.g. 0.13.0, 0.13.0rc1, 0.13.0a19, 0.13.0b10
-    pattern = r"([\d]+\.[\d]+\.[\d]*(?:a|rc|b)?[\d]+)"
+    pattern = r"([\d]+\.[\d]+\.[\d]+(?:a|rc|b)?[\d]+)"
     match = re.match(pattern, version)
     if match:
         return match.group()


### PR DESCRIPTION
The main use case of this utility being to be used in a `conf.py` file to set the `version` and `release` variables. so that the version that shows up in the HTML title isn't the expanded/ugly one we get when a build is made some time after an actual release.

```python
>>> get_release_version("0.13.0a19.post4+g0695e214")
"0.13.0a19"
```