### PR TITLE
Correctly parse the version of a final release

### DIFF
--- a/nbsite/tests/test_util.py
+++ b/nbsite/tests/test_util.py
@@ -11,6 +11,8 @@ from nbsite.util import base_version
         ("0.13.0b1", "0.13.0b1"),
         ("no.match", "no.match"),
         ("0.13.0a19.post4+g0695e214", "0.13.0a19"),
+        ("1.14.4", "1.14.4"),
+        ("1.14.4.post82+g46ba8bbf2", "1.14.4"),
         # Only 3 compontents version are matched.
         ("0.13.post4+g0695e214", "0.13.post4+g0695e214"),
         ("v0.3.0", "v0.3.0"),

--- a/nbsite/util.py
+++ b/nbsite/util.py
@@ -33,7 +33,7 @@ def base_version(version):
     Return the version passed as input if no match is found with the pattern.
     """
     # look at the start for e.g. 0.13.0, 0.13.0rc1, 0.13.0a19, 0.13.0b10
-    pattern = r"([\d]+\.[\d]+\.[\d]+(?:a|rc|b)?[\d]+)"
+    pattern = r"([\d]+\.[\d]+\.[\d]+(?:a|rc|b)?[\d]*)"
     match = re.match(pattern, version)
     if match:
         return match.group()


### PR DESCRIPTION
Small fix to the `base_version` utility to support final releases such as `1.14.4.post82+djio3ji3` -> `1.14.4`.