### PR TITLE
Small CSS fix to the Gallery navigation bar

### DIFF
--- a/nbsite/_shared_static/nbsite.css
+++ b/nbsite/_shared_static/nbsite.css
@@ -350,6 +350,7 @@ ul.tab {
     margin: 0;
     padding:0;
     border-radius: 5px;
+    overflow: hidden;
 }
 ul.tab li {
     list-style-type: none !important;


### PR DESCRIPTION
By adding `overflow: hidden` to the unordered list.

This issue was found when building holoviews' site with the pydata sphinx theme. Previously holoviews relied on a `holoviews.css` file that somehow got that right.