### PR TITLE
Add CSS to enhance headerlink

### DIFF
--- a/nbsite/_shared_static/nbsite.css
+++ b/nbsite/_shared_static/nbsite.css
@@ -531,3 +531,24 @@ div.bk-root {
 .output {
   overflow-x: auto;
 }
+
+/* Copied from the sphinx book theme */
+main.bd-content a.headerlink {
+  opacity:0;
+  margin-left:.2em
+ }
+
+ main.bd-content a.headerlink:hover {
+  background-color:transparent;
+  color:rgba(var(--pst-color-link), 1);
+  opacity:1 !important
+ }
+ 
+ main.bd-content h1:hover a.headerlink,
+ main.bd-content h2:hover a.headerlink,
+ main.bd-content h3:hover a.headerlink,
+ main.bd-content h4:hover a.headerlink,
+ main.bd-content h5:hover a.headerlink {
+  opacity:.5
+ }
+ /* End of copy  */


### PR DESCRIPTION
(The mouse is on the link character)

Before:
![image](https://user-images.githubusercontent.com/35924738/145552453-8bee8569-526c-4054-9e83-f1abb88b8e3b.png)

After:
![image](https://user-images.githubusercontent.com/35924738/145552473-90bb8566-88c0-495c-a41e-cc0deba4022e.png)

CSS copied from the sphinx book theme.

`--pst-color-headerlink` must be set in the custom CSS file per project.