### PR TITLE
Add a one line footer by default

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include nbsite/.version
 graft examples
 graft nbsite/examples
 graft nbsite/_shared_static
+graft nbsite/_shared_templates
 graft nbsite/templates

--- a/nbsite/_shared_static/nbsite.css
+++ b/nbsite/_shared_static/nbsite.css
@@ -573,7 +573,7 @@ main.bd-content a.headerlink {
   color: white;
 }
 
-/* Binder links displayed in the left sidebar when the page is built from a notebook */
+/* Binder links displayed in the right sidebar when the page is built from a notebook */
 .bd-toc #binder-link {
   display: inline-block;
   font-size: 0.9rem;

--- a/nbsite/_shared_templates/copyright-last-updated.html
+++ b/nbsite/_shared_templates/copyright-last-updated.html
@@ -1,0 +1,10 @@
+<p class="nbsite-copyright-last-updated">
+    <span class="copyright">
+        {%- if hasdoc('copyright') %}
+            {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
+        {%- else %}
+            {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+        {%- endif %}
+    </span>
+    <span class="last-updated">{% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}</span><br>
+</p>

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import datetime
 import os
 
 from nbsite import nbbuild
@@ -63,7 +64,33 @@ html_static_path = [
     )
 ]
 
+templates_path = [
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            '_shared_templates'
+        )
+    )
+]
+
 html_context = {
     'js_includes': ['nbsite.js', 'require.js'],
     'css_includes': ['nbsite.css'] 
 }
+
+# A single line footer that includes the copyright and the last updated date.
+html_theme_options = {
+    "footer_items": [
+        "copyright-last-updated",
+    ],
+}
+
+# To be reused in a conf.py file to define the `copyright` string reused
+# by sphinx to populate the footer content:
+# copyright_years['start_year'] = '2000'
+# copyright = copyright_fmt.format(**copyright_years)
+copyright_years = {'current_year': str(datetime.date.today().year)}
+copyright_fmt = "© Copyright {start_year}-{current_year} Holoviz contributors."
+
+# Format of the last updated date in the footer.
+html_last_updated_fmt = '%Y-%m-%d'


### PR DESCRIPTION
* Add a template that displays on a single line the copyright and the last updated date. It is basically a merge of the `copyright` and `last-updated` templates of the pydata sphinx theme.
* Add utilities to simplify defining the copyright among holoviz packages.