### PR TITLE
Pin jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup_args = dict(
         'myst-nb',
         'notebook',
         'sphinx',
-        'beautifulsoup4'
+        'beautifulsoup4',
+        'jinja2 <3.1',
     ],
     extras_require= {
         'refman':[


### PR DESCRIPTION
jinja2 made a backwards incompatible change in its 3.1 release that broke a few packages around. nbconvert was one of them, they released a couple of days ago a new version with a fix for jinja2. However nbsite is pinning nbconvert to an older version <6, that is very unlikely to be patched by nbconvert. While updating nbsite to support nbconvert 6 should be a goal at some point (or using another client), for now nbsite will just pin jinja2 < 3.1.