### PR TITLE
Redesign gallery based on sphinx-design library

### DIFF
--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -40,6 +40,7 @@ def remove_mystnb_static(app):
 
 extensions = [
     'myst_nb',
+    'sphinx_design',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup_args = dict(
         'nbconvert <6.0',
         'jupyter_client <6.2',
         'myst-nb <0.14',
+        'sphinx-design',
         'notebook',
         'sphinx',
         'beautifulsoup4',


### PR DESCRIPTION
Instead of custom hacky HTML/CSS we now use sphinx-design grids and cards:

<img width="2042" alt="Screen Shot 2022-05-29 at 19 14 50" src="https://user-images.githubusercontent.com/1550771/170882989-97fe7e20-a03a-4d99-a35f-d7e4b233508d.png">
