### PR TITLE
Add pydata-sphinx-theme (pinned) and myst-parser to the runtime dependencies

### DIFF
--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -50,6 +50,9 @@ extensions = [
     'sphinx.ext.inheritance_diagram',
 ]
 
+# Default theme is the PyData Sphinx Theme
+html_theme = "pydata_sphinx_theme"
+
 inheritance_graph_attrs = dict(
     rankdir="LR",
     size='"12.0, 12.0"',

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup_args = dict(
         'sphinx',
         'beautifulsoup4',
         'jinja2 <3.1',
+        'pydata-sphinx-theme <0.9.0',
     ],
     extras_require= {
         'refman':[

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_args = dict(
         'beautifulsoup4',
         'jinja2 <3.1',
         'pydata-sphinx-theme <0.9.0',
+        'myst-parser',
     ],
     extras_require= {
         'refman':[


### PR DESCRIPTION
For two reasons:

* each HoloViz project now relies on the Pydata Sphinx Theme to build its docs, it makes sense to add it as a dependency here. Each project is anyway allowed to override the default theme. Pretty much the same idea for `myst-parser`, that is anyway a dependency of `myst-nb` (already a dependency of nbsite) but it's better to be explicit as some projects already rely on MyST markdown
* the latest release of the Pydata Sphinx Theme made some larger changes which have been adapted at Panel's level but it's still an on-going work, so in the meantime let's just pin it to the previous version. Especially because we expect to make some releases soon.
