### PR TITLE
Compatibility with the latest Pydata Sphinx Theme and more upstreaming

### DIFF
--- a/nbsite/_shared_templates/sections/sidebar-primary.html
+++ b/nbsite/_shared_templates/sections/sidebar-primary.html
@@ -1,0 +1,21 @@
+<!-- nbsite override: to reduce the side bar length by changing -->
+<!-- col-md-3 to col-md-2 -->
+{% block docs_sidebar %}
+{% if sidebars %}
+<!-- Only show if we have sidebars configured, else just a small margin  -->
+<div class="bd-sidebar-primary col-12 col-md-2 bd-sidebar">
+  <div class="sidebar-start-items">
+    {%- for sidebartemplate in sidebars %}
+    {%- include sidebartemplate %}
+    {%- endfor %}
+  </div>
+  <div class="sidebar-end-items">
+    {%- for leftsidebartemplate in theme_left_sidebar_end %}
+    {%- include leftsidebartemplate %}
+    {%- endfor %}
+  </div>
+</div>
+{% else %}
+<div class="sidebar-primary col-12 col-md-1 col-xl-2 bd-sidebar no-sidebar"></div>
+{% endif %}
+{% endblock %}

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -111,6 +111,9 @@ html_theme_options = {
     "default_mode": "light"
 }
 
+# Enable the colon_fence myst extension: https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#code-fences-using-colons
+myst_enable_extensions = ["colon_fence"]
+
 # To be reused in a conf.py file to define the `copyright` string reused
 # by sphinx to populate the footer content:
 # copyright_years['start_year'] = '2000'

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -40,6 +40,7 @@ def remove_mystnb_static(app):
 
 extensions = [
     'myst_nb',
+    'sphinx_copybutton',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -107,6 +107,8 @@ html_theme_options = {
     # Override the navbar end not to include the theme switcher
     # as plots and likes don't yet render very well in dark mode
     "navbar_end": ["navbar-icon-links"],
+    # Enforce the light mode
+    "default_mode": "light"
 }
 
 # To be reused in a conf.py file to define the `copyright` string reused

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -100,6 +100,9 @@ html_theme_options = {
     "footer_items": [
         "copyright-last-updated",
     ],
+    # Pygment to modify the code highlighting colors in light and dark mode
+    "pygment_light_style": "monokai",
+    "pygment_dark_style": "monokai"
 }
 
 # To be reused in a conf.py file to define the `copyright` string reused

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -103,7 +103,10 @@ html_theme_options = {
     ],
     # Pygment to modify the code highlighting colors in light and dark mode
     "pygment_light_style": "monokai",
-    "pygment_dark_style": "monokai"
+    "pygment_dark_style": "monokai",
+    # Override the navbar end not to include the theme switcher
+    # as plots and likes don't yet render very well in dark mode
+    "navbar_end": ["navbar-icon-links"],
 }
 
 # To be reused in a conf.py file to define the `copyright` string reused

--- a/nbsite/shared_conf.py
+++ b/nbsite/shared_conf.py
@@ -41,6 +41,7 @@ def remove_mystnb_static(app):
 extensions = [
     'myst_nb',
     'sphinx_copybutton',
+    'sphinx_design',
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup_args = dict(
         'pydata-sphinx-theme <0.9.0',
         'myst-parser',
         'sphinx-copybutton',
+        'sphinx-design',
     ],
     extras_require= {
         'refman':[

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup_args = dict(
         'jinja2 <3.1',
         'pydata-sphinx-theme <0.9.0',
         'myst-parser',
+        'sphinx-copybutton',
     ],
     extras_require= {
         'refman':[


### PR DESCRIPTION
I would like `nbsite` to pre-configure as much possible the `conf.py` and provide the templates and CSS required so that there's no more copy/pasting across the HoloViz projects. If a project isn't satisfied with the pre-configuration, it can still override it in `conf.py`. Actually this is an opt-in mechanism, you have to write something like `html_static_path += ['folder']` to inherit from the pre-configuration provided by `nbsite`.