### PR TITLE
Unpin the pydata sphinx theme

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup_args = dict(
         'sphinx',
         'beautifulsoup4',
         'jinja2 <3.1',
-        'pydata-sphinx-theme <0.9.0',
+        'pydata-sphinx-theme',
         'myst-parser',
     ],
     extras_require= {


### PR DESCRIPTION
It is going to be the responsibility of each project to pin the version of the pydata sphinx theme they want to adhere to. As it stands the styling changes being made in Panel to adapt to the new features of the theme have not yet been finished and haven't been discussed in the team, to see whether they could be upstreamed to nbsite in the spirit of DRY.