### PR TITLE
Ensure kernel is ready before sending execute_request messages

### DIFF
--- a/nbsite/nbbuild.py
+++ b/nbsite/nbbuild.py
@@ -98,6 +98,9 @@ class ExecutePreprocessor1000(ExecutePreprocessor):
     def kc(self, v):
         self._kc = v
         if v is not None and self._ipython_startup is not None:
+            # Ensure kernel is running and ready to receive execute_request messages.
+            # This is important for ipykernel >= 7
+            self._kc.kernel_info()
             self._kc.execute(
                 self._ipython_startup,
                 silent=False,

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,7 +43,7 @@ no-default-feature = true
 
 [feature.required.dependencies]
 beautifulsoup4 = "*"
-ipykernel = "<7.0.0"  # Temp pin
+ipykernel = "*"
 jinja2 = "*"
 jupyter_client = "*"
 myst-nb = ">=1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dependencies = [
     'sphinxext-rediraffe',
     'packaging',
     'requests',
-    'ipykernel <7.0',  # Temp. dependency
 ]
 
 [project.scripts]


### PR DESCRIPTION
Fixes #349.

It is possible to send an `execute_request` message too early to an `ipykernel` kernel, before it is ready to process that message. The recommendation is to send a `kernel_info_request` message first and wait for the reply, which is the change added here. There is some complicated logic in some `jupyter` libraries to deal with this which boils down to wait for the `kernel_info_reply` message and you will be OK.

Without the `kernel_info_request` it is possible to get timing-related errors. This has always been the case but is more likely now with `ipykernel >= 7` as more resources (threads, ZMQ sockets) are created.

This fixes the problem for me locally on Linux, let's see if CI is happy with it.

I suspect there are other libraries downstream of `ipykernel` that also suffer from this, so I am hoping to make some changes to `ipykernel` to improve the situation. There are separate proposals to improve `jupyter_server`'s handling of it, and to allow the kernel to push a "I am ready" notification rather than using `kernel_info_request`. But keeping the `kernel_info_request` here will never be wrong.