### PR TITLE
enh: Add lxml for `_fix_links.py`

### DIFF
--- a/nbsite/scripts/_fix_links.py
+++ b/nbsite/scripts/_fix_links.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from pathlib import Path
 
-from bs4 import BeautifulSoup
+from lxml import html as lhtml
 
 # TODO: holoviews specific links e.g. to reference manual...doc & generalize
 
@@ -95,43 +95,40 @@ def cleanup_links(path, inspect_links=False):
 #            text = text.replace(k, v)
 
     text = component_links(text, path)
-    soup = BeautifulSoup(text, features="html.parser")
-    for a in soup.find_all('a'):
+    tree = lhtml.document_fromstring(text)
+    for a in tree.iter('a'):
         href = a.get('href', '')
         if '.ipynb' in href and 'http' not in href:
- #           for k, v in LINK_REPLACEMENTS.items():
- #               href = href.replace(k, v)
-            a['href'] = href.replace('.ipynb', '.html')
+            a.set('href', href.replace('.ipynb', '.html'))
 
-            # check to make sure that path exists, if not, try un-numbered version
-            try_path = os.path.join(os.path.dirname(path), a['href'])
+            try_path = os.path.join(os.path.dirname(path), a.get('href'))
             if not os.path.exists(try_path):
                 num_name = os.path.basename(try_path)
                 name = re.split(r"^#?\d+( |-|_)", num_name)[-1]
                 new_path = try_path.replace(num_name, name)
                 if os.path.exists(new_path):
-                    a['href'] = os.path.relpath(new_path, os.path.dirname(path))
+                    a.set('href', os.path.relpath(new_path, os.path.dirname(path)))
                 else:
                     also_tried = 'Also tried: {}'.format(name) if name != num_name else ''
-                    msg = 'Found missing link {} in: {}. {}'.format(a['href'], path, also_tried)
+                    msg = 'Found missing link {} in: {}. {}'.format(a.get('href'), path, also_tried)
                     warnings.warn(msg)
 
-        if inspect_links and 'http' in a['href']:
-            print(a['href'])
+        if inspect_links and 'http' in href:
+            print(href)
 
-    for img in soup.find_all('img'):
+    for img in tree.iter('img'):
         src = img.get('src', '')
         if 'http' not in src and 'assets' in src:
             try_path = os.path.join(os.path.dirname(path), src)
             if not os.path.exists(try_path):
                 also_tried = os.path.join('..', src)
                 if os.path.exists(os.path.join(os.path.dirname(path), also_tried)):
-                    img['src'] = also_tried
+                    img.set('src', also_tried)
                 else:
                     msg = f'Found reference to missing image {src} in: {path}. Also tried: {also_tried}'
                     warnings.warn(msg)
     with open(path, 'w', encoding='utf-8') as f:
-        f.write(str(soup))
+        f.write(lhtml.tostring(tree, doctype='<!DOCTYPE html>', encoding='unicode'))
 
 def fix_links(build_dir, inspect_links=False):
     files = map(os.fspath, Path(build_dir).rglob("*.html"))

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,6 +46,7 @@ beautifulsoup4 = "*"
 ipykernel = "*"
 jinja2 = "*"
 jupyter_client = "*"
+lxml = "*"
 myst-nb = ">=1.1"
 myst-parser = '>=3'
 nbconvert = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     'sphinxext-rediraffe',
     'packaging',
     'requests',
+    'lxml',
 ]
 
 [project.scripts]


### PR DESCRIPTION
Something which have been in my stack for the longest time

Benchmark: 

```
HTML size: 3,278 bytes

html.parser (BeautifulSoup)    200 iters  0.428s  (2.14 ms/iter)
lxml (BeautifulSoup)           200 iters  0.338s  (1.69 ms/iter)
lxml (pure)                    200 iters  0.023s  (0.11 ms/iter)
```

``` python
"""
Benchmark: BeautifulSoup html.parser vs lxml (BeautifulSoup) vs pure lxml for cleanup_links.
"""
import os
import re
import timeit
import warnings
from pathlib import Path

from bs4 import BeautifulSoup
from lxml import etree, html as lhtml


def make_html(n_links=50, n_imgs=20):
    links = "\n".join(
        f'<a href="notebook_{i}.ipynb">link {i}</a>' for i in range(n_links)
    )
    imgs = "\n".join(
        f'<img src="assets/image_{i}.png" />' for i in range(n_imgs)
    )
    external = "\n".join(
        f'<a href="https://example.com/page{i}">ext {i}</a>' for i in range(10)
    )
    return f"""<!DOCTYPE html>
<html>
<head><title>Test</title></head>
<body>
<div class="content">
{links}
{external}
{imgs}
<p>Some <code>Element</code> text and more content here.</p>
</div>
</body>
</html>"""


def process_bs4(text, parser):
    soup = BeautifulSoup(text, features=parser)
    for a in soup.find_all("a"):
        href = a.get("href", "")
        if ".ipynb" in href and "http" not in href:
            a["href"] = href.replace(".ipynb", ".html")
    for img in soup.find_all("img"):
        src = img.get("src", "")
        if "http" not in src and "assets" in src:
            pass  # would check path; skip filesystem ops in benchmark
    return str(soup)


def process_lxml(text):
    tree = lhtml.fromstring(text)
    for a in tree.iter("a"):
        href = a.get("href", "")
        if ".ipynb" in href and "http" not in href:
            a.set("href", href.replace(".ipynb", ".html"))
    for img in tree.iter("img"):
        src = img.get("src", "")
        if "http" not in src and "assets" in src:
            pass
    return lhtml.tostring(tree, doctype="<!DOCTYPE html>", encoding="unicode")


def run(label, fn, html, n=200):
    elapsed = timeit.timeit(lambda: fn(html), number=n)
    print(f"{label:<30} {n} iters  {elapsed:.3f}s  ({elapsed/n*1000:.2f} ms/iter)")


if __name__ == "__main__":
    html = make_html(n_links=50, n_imgs=20)
    print(f"HTML size: {len(html):,} bytes\n")

    run("html.parser (BeautifulSoup)", lambda h: process_bs4(h, "html.parser"), html)
    run("lxml (BeautifulSoup)",        lambda h: process_bs4(h, "lxml"),        html)
    run("lxml (pure)",                 process_lxml,                             html)
```